### PR TITLE
fix(api): validate and sanitize interview create/save payloads

### DIFF
--- a/routes/interview_routes.py
+++ b/routes/interview_routes.py
@@ -1,8 +1,45 @@
-from flask import Blueprint, request, jsonify, render_template
-from models.interview import create_interview, save_answers, get_interview
+import re
 import uuid
 
+from flask import Blueprint, request, jsonify, render_template
+
+from models.interview import create_interview, save_answers, get_interview
+
 interview_bp = Blueprint("interview", __name__)
+
+ROOM_ID_PATTERN = re.compile(r"^[A-Z0-9_-]{4,16}$")
+MAX_NAME_LENGTH = 80
+MAX_ROLE_LENGTH = 80
+MAX_ANSWERS_LENGTH = 10000
+
+
+def _require_json_object():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "Request body must be valid JSON"}), 400)
+    return data, None
+
+
+def _sanitize_text(value):
+    # Remove control characters while preserving user-visible text.
+    return re.sub(r"[\x00-\x1F\x7F]", "", value).strip()
+
+
+def _validate_required_string(data, field_name, max_length):
+    value = data.get(field_name)
+
+    if value is None:
+        return None, f"'{field_name}' is required"
+    if not isinstance(value, str):
+        return None, f"'{field_name}' must be a string"
+
+    cleaned = _sanitize_text(value)
+    if not cleaned:
+        return None, f"'{field_name}' cannot be empty"
+    if len(cleaned) > max_length:
+        return None, f"'{field_name}' must be <= {max_length} characters"
+
+    return cleaned, None
 
 
 @interview_bp.route("/interview/create", methods=["GET"])
@@ -20,10 +57,33 @@ def room_page(room_id):
 
 @interview_bp.route("/api/interview/create", methods=["POST"])
 def create():
-    data = request.json
-    room_id = data.get("room_id") or str(uuid.uuid4())[:8]
-    role = data.get("role", "Software Developer")
-    candidate_name = data.get("candidate_name", "Candidate")
+    data, error = _require_json_object()
+    if error:
+        return error
+
+    raw_room_id = data.get("room_id")
+    if raw_room_id is None or raw_room_id == "":
+        room_id = str(uuid.uuid4())[:8].upper()
+    else:
+        if not isinstance(raw_room_id, str):
+            return jsonify({"error": "'room_id' must be a string"}), 400
+        room_id = _sanitize_text(raw_room_id).upper()
+        if not ROOM_ID_PATTERN.fullmatch(room_id):
+            return jsonify({"error": "'room_id' must be 4-16 chars (A-Z, 0-9, _, -)"}), 400
+
+    candidate_name, candidate_name_error = _validate_required_string(
+        data, "candidate_name", MAX_NAME_LENGTH
+    )
+    if candidate_name_error:
+        return jsonify({"error": candidate_name_error}), 400
+
+    role_value = data.get("role", "Software Developer")
+    if not isinstance(role_value, str):
+        return jsonify({"error": "'role' must be a string"}), 400
+
+    role = _sanitize_text(role_value) or "Software Developer"
+    if len(role) > MAX_ROLE_LENGTH:
+        return jsonify({"error": f"'role' must be <= {MAX_ROLE_LENGTH} characters"}), 400
 
     try:
         create_interview(room_id, role, candidate_name)
@@ -44,8 +104,18 @@ def get(room_id):
 
 @interview_bp.route("/api/interview/<room_id>/answers", methods=["POST"])
 def save(room_id):
-    data = request.json
-    answers = data.get("answers", "")
+    data, error = _require_json_object()
+    if error:
+        return error
+
+    answers, answers_error = _validate_required_string(
+        data, "answers", MAX_ANSWERS_LENGTH
+    )
+    if answers_error:
+        return jsonify({"error": answers_error}), 400
+
+    if not get_interview(room_id):
+        return jsonify({"error": "Interview not found"}), 404
 
     try:
         save_answers(room_id, answers)


### PR DESCRIPTION
```NSoC'26```
## Title
``` fix(api): validate and sanitize interview create/save payloads ```

## Description
### Summary
This PR improves API input handling for interview creation and answer submission by adding structured validation and lightweight sanitization.

## Changes Made

- Added JSON body validation to reject non-object/invalid JSON payloads with 400.
- Added reusable string validation helper for required fields.
- Added lightweight sanitization (trim + control-character stripping).
- Hardened ``` POST /api/interview/create```:
    - Validates ```room_id``` type/format (A-Z, 0-9, _, -, length 4-16)
    - Validates ```candidate_name``` (required, string, non-empty, max length)
    - Validates role (string, max length, fallback default)
- Hardened ```POST /api/interview/<room_id>/answers```:
   - Validates ```answers``` (required, string, non-empty, max length)
   - Returns ```404``` when interview room does not exist before save
  

## Why
This addresses issue #5 by preventing invalid payloads from reaching DB logic and by returning clear client-facing errors (400/404) instead of generic failures.

API Behavior
Invalid JSON body ->``` 400 {"error": "Request body must be valid JSON"}```
Invalid field type/empty/oversized values -> ```400``` with field-specific error
Saving answers for unknown room -> ```404 {"error": "Interview not found"}```

## Testing
Manually verified with Flask test client:

Create interview with invalid JSON -> ```400```
Create interview with invalid ```candidate_name``` type -> ```400```
Create interview with valid payload -> ```200```
Save answers for missing room -> ```404```
Save answers for valid room -> ```200```
Related Issue
Closes #5