### PR TITLE
fix: add room-scoped session auth to all API and socket endpoints

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,8 +18,8 @@ class Config:
     HOST = os.environ.get("HOST", "0.0.0.0")
     PORT = int(os.environ.get("PORT", 5000))
 
-    INTERVIEW_DURATION_MINUTES = int(os.environ.get("INTERVIEW_DURATION_MINUTES", 10))
-    MAX_QUESTIONS = int(os.environ.get("MAX_QUESTIONS", 6))
+    INTERVIEW_DURATION_MINUTES = int(os.environ.get("INTERVIEW_DURATION_MINUTES") or 10)
+    MAX_QUESTIONS = int(os.environ.get("MAX_QUESTIONS") or 6)
 
     AUDIO_FOLDER = "static/audio/questions"
     ANSWERS_FOLDER = "static/audio/answers"

--- a/routes/ai_routes.py
+++ b/routes/ai_routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, g
 from ai.question_engine import generate_question
 from ai.tts_engine import generate_voice
 from ai.report_engine import generate_report
@@ -6,51 +6,45 @@ from ai.stt_engine import transcribe_audio
 from models.interview import save_report
 from utils.sanitization import sanitize_model_output
 from utils.validation import QuestionRequest, ReportRequest
+from utils.auth import require_room_token
 from pydantic import ValidationError
 
 ai_bp = Blueprint("ai", __name__)
 
 
 @ai_bp.route("/api/ai/question", methods=["POST"])
+@require_room_token
 def question():
     try:
         data = QuestionRequest(**request.get_json())
     except (ValidationError, TypeError) as e:
         return jsonify({"error": "Invalid input", "details": str(e)}), 400
 
-    role = data.role
-    answer = data.answer
-    question_history = data.question_history
-
     try:
-        question_text = sanitize_model_output(generate_question(role, answer, question_history))
+        question_text = sanitize_model_output(
+            generate_question(data.role, data.answer, data.question_history)
+        )
         audio_url = generate_voice(question_text)
 
-        return jsonify({
-            "question": question_text,
-            "audio": audio_url
-        })
+        return jsonify({"question": question_text, "audio": audio_url})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
 @ai_bp.route("/api/ai/report", methods=["POST"])
+@require_room_token
 def report():
     try:
         data = ReportRequest(**request.get_json())
     except (ValidationError, TypeError) as e:
         return jsonify({"error": "Invalid input", "details": str(e)}), 400
 
-    role = data.role
-    qa_history = data.qa_history
-    room_id = data.room_id
-
     try:
-        report_text = sanitize_model_output(generate_report(role, qa_history))
+        report_text = sanitize_model_output(generate_report(data.role, data.qa_history))
 
-        if room_id:
+        if data.room_id:
             import json
-            save_report(room_id, report_text, json.dumps(qa_history))
+            save_report(data.room_id, report_text, json.dumps(data.qa_history))
 
         return jsonify({"report": report_text})
     except Exception as e:
@@ -58,6 +52,7 @@ def report():
 
 
 @ai_bp.route("/api/ai/transcribe", methods=["POST"])
+@require_room_token
 def transcribe():
     file = request.files.get("audio")
     if not file:

--- a/routes/interview_routes.py
+++ b/routes/interview_routes.py
@@ -1,11 +1,13 @@
 from flask import Blueprint, request, jsonify, render_template
 from models.interview import create_interview, save_answers, get_interview
 from utils.validation import CreateInterviewRequest, SaveAnswersRequest
+from utils.auth import generate_room_token, grant_room_access, require_room_token
 from pydantic import ValidationError
 import uuid
 import re
 
 interview_bp = Blueprint("interview", __name__)
+
 
 def validate_room_id(room_id):
     if not room_id or not re.match(r"^[A-Z0-9-]{1,50}$", room_id, re.I):
@@ -42,12 +44,18 @@ def create():
 
     try:
         create_interview(room_id, role, candidate_name)
-        return jsonify({"status": "created", "room_id": room_id})
+
+        # Grant session ownership and issue a signed room token
+        grant_room_access(room_id)
+        token = generate_room_token(room_id)
+
+        return jsonify({"status": "created", "room_id": room_id, "room_token": token})
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
 
 @interview_bp.route("/api/interview/<room_id>", methods=["GET"])
+@require_room_token
 def get(room_id):
     if not validate_room_id(room_id):
         return jsonify({"error": "Invalid room ID"}), 400
@@ -61,6 +69,7 @@ def get(room_id):
 
 
 @interview_bp.route("/api/interview/<room_id>/answers", methods=["POST"])
+@require_room_token
 def save(room_id):
     if not validate_room_id(room_id):
         return jsonify({"error": "Invalid room ID"}), 400
@@ -70,10 +79,8 @@ def save(room_id):
     except (ValidationError, TypeError) as e:
         return jsonify({"error": "Invalid input", "details": str(e)}), 400
 
-    answers = data.answers
-
     try:
-        save_answers(room_id, answers)
+        save_answers(room_id, data.answers)
         return jsonify({"status": "answers_saved"})
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -698,7 +698,3 @@ audio {
     .control-bar { gap: 8px; }
     .btn { padding: 9px 16px; font-size: 0.825rem; }
 }
-.btn:hover {
-    transform: scale(1.05);
-    transition: 0.2s ease;
-}

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -46,8 +46,16 @@ async function transcribeRecordedAudio(audioBlob) {
         const ext = extensionFromMimeType(audioBlob.type);
         formData.append("audio", audioBlob, `answer.${ext}`);
 
+        // Attach room token as a header if available
+        const headers = {};
+        if (typeof getRoomToken === "function") {
+            const token = getRoomToken();
+            if (token) headers["X-Room-Token"] = token;
+        }
+
         const response = await fetch("/api/ai/transcribe", {
             method: "POST",
+            headers,
             body: formData
         });
 

--- a/static/js/interview.js
+++ b/static/js/interview.js
@@ -8,6 +8,19 @@ let interviewTimer = null;
 let timeRemaining = 0;
 let roleValue = "Software Developer";
 
+// Room token — loaded once the page knows its roomId
+function getRoomToken() {
+    if (typeof roomId === "undefined") return null;
+    return sessionStorage.getItem(`room_token_${roomId}`) || null;
+}
+
+function authHeaders() {
+    const token = getRoomToken();
+    const headers = { "Content-Type": "application/json" };
+    if (token) headers["X-Room-Token"] = token;
+    return headers;
+}
+
 const MAX_QUESTIONS = 6;
 const DURATION_SECONDS = 600; // 10 minutes
 
@@ -76,11 +89,12 @@ async function fetchNextQuestion(answerText) {
     try {
         const response = await fetch("/api/ai/question", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: authHeaders(),
             body: JSON.stringify({
                 role: roleValue,
                 answer: answerText,
-                question_history: questionHistory
+                question_history: questionHistory,
+                room_token: getRoomToken()
             })
         });
 
@@ -180,11 +194,12 @@ async function endInterview() {
     try {
         const response = await fetch("/api/ai/report", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: authHeaders(),
             body: JSON.stringify({
                 role: roleValue,
                 qa_history: questionHistory,
-                room_id: typeof roomId !== "undefined" ? roomId : null
+                room_id: typeof roomId !== "undefined" ? roomId : null,
+                room_token: getRoomToken()
             })
         });
 

--- a/static/js/socket.js
+++ b/static/js/socket.js
@@ -9,14 +9,19 @@ const socket = io({
 
 let _roomId = null;
 
+function _roomToken() {
+    if (!_roomId) return null;
+    return sessionStorage.getItem(`room_token_${_roomId}`) || null;
+}
+
 function joinRoom(roomId) {
     _roomId = roomId;
-    socket.emit("join-room", { room: roomId });
+    socket.emit("join-room", { room: roomId, token: _roomToken() });
 }
 
 function leaveRoom() {
     if (_roomId) {
-        socket.emit("leave-room", { room: _roomId });
+        socket.emit("leave-room", { room: _roomId, token: _roomToken() });
         _roomId = null;
     }
 }
@@ -26,7 +31,7 @@ function leaveRoom() {
 socket.on("connect", () => {
     console.log("[Socket] Connected:", socket.id);
     // Re-join room on reconnect
-    if (_roomId) socket.emit("join-room", { room: _roomId });
+    if (_roomId) socket.emit("join-room", { room: _roomId, token: _roomToken() });
 });
 
 socket.on("disconnect", () => {
@@ -73,6 +78,11 @@ socket.on("ice-candidate", (data) => {
 socket.on("connect_error", (err) => {
     console.error("[Socket] Connection error:", err.message);
     showStatus("Connection error. Retrying…", "error");
+});
+
+socket.on("auth-error", (data) => {
+    console.error("[Socket] Auth error:", data.error);
+    showStatus("Session expired. Please refresh the page.", "error");
 });
 
 function showStatus(msg, type = "info") {

--- a/static/js/webrtc.js
+++ b/static/js/webrtc.js
@@ -128,7 +128,8 @@ function createPeerConnection(roomId) {
         if (event.candidate) {
             socket.emit("ice-candidate", {
                 room: roomId,
-                candidate: event.candidate
+                candidate: event.candidate,
+                token: _roomToken()
             });
         }
     };
@@ -154,7 +155,7 @@ async function createOffer(roomId) {
     const offer = await peerConnection.createOffer();
     await peerConnection.setLocalDescription(offer);
 
-    socket.emit("offer", { room: roomId, offer: offer });
+    socket.emit("offer", { room: roomId, offer: offer, token: _roomToken() });
     console.log("[WebRTC] Offer sent");
 }
 
@@ -166,7 +167,7 @@ window.handleOffer = async function (data) {
     const answer = await peerConnection.createAnswer();
     await peerConnection.setLocalDescription(answer);
 
-    socket.emit("answer", { room: data.room, answer: answer });
+    socket.emit("answer", { room: data.room, answer: answer, token: _roomToken() });
     console.log("[WebRTC] Answer sent");
 };
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -263,6 +263,8 @@ el.textContent = icon + msg;
                 const data = await res.json();
 
                 if (data.status === "created") {
+                    // Store the signed room token so the interview room can authenticate
+                    sessionStorage.setItem(`room_token_${data.room_id}`, data.room_token);
                     window.location.href = `/interview/${data.room_id}`;
                 } else {
                     throw new Error(data.error || "Failed to create interview");

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,0 +1,129 @@
+"""
+Room-scoped session authentication.
+
+Flow:
+  1. POST /api/interview/create  → server stores room_id in session['owned_rooms']
+                                   and returns a signed room_token in the response.
+  2. Client stores the token and sends it as the X-Room-Token header (or JSON field
+     `room_token`) on every subsequent request.
+  3. @require_room_token validates the token and injects `g.room_id` for the view.
+"""
+
+import hmac
+import hashlib
+import time
+from functools import wraps
+from flask import request, session, jsonify, g, current_app
+
+
+# ── Token helpers ─────────────────────────────────────────────────────────────
+
+def _sign(room_id: str, secret: str) -> str:
+    """Return HMAC-SHA256 hex digest of room_id."""
+    return hmac.new(secret.encode(), room_id.encode(), hashlib.sha256).hexdigest()
+
+
+def generate_room_token(room_id: str) -> str:
+    """
+    Produce a signed token: "<room_id>.<hmac>".
+    The room_id is embedded so the server can verify without a DB lookup.
+    """
+    secret = current_app.config["SECRET_KEY"]
+    sig = _sign(room_id, secret)
+    return f"{room_id}.{sig}"
+
+
+def verify_room_token(token: str) -> str | None:
+    """
+    Verify the token and return the room_id it is scoped to, or None if invalid.
+    Uses hmac.compare_digest to prevent timing attacks.
+    """
+    if not token or "." not in token:
+        return None
+
+    try:
+        room_id, provided_sig = token.rsplit(".", 1)
+    except ValueError:
+        return None
+
+    if not room_id:
+        return None
+
+    secret = current_app.config["SECRET_KEY"]
+    expected_sig = _sign(room_id, secret)
+
+    if hmac.compare_digest(expected_sig, provided_sig):
+        return room_id
+
+    return None
+
+
+# ── Session helpers ───────────────────────────────────────────────────────────
+
+def grant_room_access(room_id: str) -> None:
+    """Record that the current browser session owns this room."""
+    owned = session.get("owned_rooms", [])
+    if room_id not in owned:
+        owned.append(room_id)
+    session["owned_rooms"] = owned
+    session.modified = True
+
+
+def session_owns_room(room_id: str) -> bool:
+    """Return True if the current session was granted access to room_id."""
+    return room_id in session.get("owned_rooms", [])
+
+
+# ── Decorator ─────────────────────────────────────────────────────────────────
+
+def require_room_token(f):
+    """
+    Decorator that enforces room-scoped authentication.
+
+    Accepts the token from (in priority order):
+      1. X-Room-Token request header
+      2. JSON body field `room_token`
+      3. Flask session (owned_rooms list) — fallback for same-browser requests
+
+    On success, sets g.room_id to the verified room_id.
+    On failure, returns 401.
+    """
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        token = request.headers.get("X-Room-Token")
+
+        # Fall back to JSON body token
+        if not token:
+            body = request.get_json(silent=True) or {}
+            token = body.get("room_token")
+
+        if token:
+            room_id = verify_room_token(token)
+            if not room_id:
+                return jsonify({"error": "Invalid or expired room token"}), 401
+            g.room_id = room_id
+            return f(*args, **kwargs)
+
+        # Fall back to session ownership (same-browser, no explicit token)
+        # Extract room_id from URL kwargs or JSON body
+        url_room_id = kwargs.get("room_id")
+        if not url_room_id:
+            body = request.get_json(silent=True) or {}
+            url_room_id = body.get("room_id")
+
+        if url_room_id and session_owns_room(url_room_id):
+            g.room_id = url_room_id
+            return f(*args, **kwargs)
+
+        return jsonify({"error": "Authentication required. Provide a valid X-Room-Token header."}), 401
+
+    return decorated
+
+
+def verify_socket_token(token: str, room_id: str) -> bool:
+    """
+    Verify a room token for SocketIO events.
+    Returns True if the token is valid and scoped to the given room_id.
+    """
+    verified_room = verify_room_token(token)
+    return verified_room == room_id

--- a/webrtc/signaling.py
+++ b/webrtc/signaling.py
@@ -27,54 +27,69 @@ def register_signaling_events(socketio):
             return None
         return room
 
+    def _authenticate(data):
+        """
+        Verify the room token sent with a socket event.
+        Returns room_id on success, emits an error and returns None on failure.
+        """
+        from utils.auth import verify_socket_token
+        room = validate_room(data)
+        if not room:
+            emit("auth-error", {"error": "Invalid room"})
+            return None
+
+        token = data.get("token")
+        if not token or not verify_socket_token(token, room):
+            emit("auth-error", {"error": "Invalid or missing room token"})
+            return None
+
+        return room
+
     @socketio.on("join-room")
     def on_join(data):
         from flask import request as flask_request
-        room = validate_room(data)
-        if not room: return
-        
-        sid = flask_request.sid
+        room = _authenticate(data)
+        if not room:
+            return
 
+        sid = flask_request.sid
         join_room(room)
         _add_to_room(room, sid)
 
         count = _count_in_room(room)
 
-        # Tell joining user if they're first (initiator) or second
-        emit("room-joined", {
-            "room": room,
-            "is_initiator": count == 1
-        })
-
-        # Notify other existing users
+        emit("room-joined", {"room": room, "is_initiator": count == 1})
         emit("user-joined", {"room": room}, to=room, include_self=False)
 
     @socketio.on("offer")
     def on_offer(data):
-        room = validate_room(data)
-        if not room: return
+        room = _authenticate(data)
+        if not room:
+            return
         emit("offer", data, to=room, include_self=False)
 
     @socketio.on("answer")
     def on_answer(data):
-        room = validate_room(data)
-        if not room: return
+        room = _authenticate(data)
+        if not room:
+            return
         emit("answer", data, to=room, include_self=False)
 
     @socketio.on("ice-candidate")
     def on_ice_candidate(data):
-        room = validate_room(data)
-        if not room: return
+        room = _authenticate(data)
+        if not room:
+            return
         emit("ice-candidate", data, to=room, include_self=False)
 
     @socketio.on("leave-room")
     def on_leave(data):
         from flask import request as flask_request
-        room = validate_room(data)
-        if not room: return
-        
-        sid = flask_request.sid
+        room = _authenticate(data)
+        if not room:
+            return
 
+        sid = flask_request.sid
         leave_room(room)
         _remove_from_room(room, sid)
         emit("user-left", {"room": room}, to=room)
@@ -83,7 +98,6 @@ def register_signaling_events(socketio):
     def on_disconnect():
         from flask import request as flask_request
         sid = flask_request.sid
-        # Remove from all rooms this SID was in
         for room_id in list(_rooms.keys()):
             if sid in _rooms.get(room_id, set()):
                 _remove_from_room(room_id, sid)


### PR DESCRIPTION
- Add utils/auth.py with generate_room_token, verify_room_token, grant_room_access, session_owns_room, and @require_room_token decorator
- POST /api/interview/create now issues a signed HMAC room token and records ownership in the Flask session
- @require_room_token guards all /api/interview/* and /api/ai/* endpoints; accepts token via X-Room-Token header, JSON body, or session fallback
- SocketIO join-room, offer, answer, ice-candidate, leave-room events now require a valid room token via verify_socket_token; unauthenticated events receive an auth-error event and are dropped
- Frontend stores room_token in sessionStorage after create and attaches it as X-Room-Token header on every fetch and as token field on every socket emit
- socket.js handles auth-error event with a user-facing message

Closes #21