### PR TITLE
feat: add authentication and rate limiting

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,9 +11,13 @@ from models.interview import init_db
 from routes.ai_routes import ai_bp
 from routes.interview_routes import interview_bp
 from webrtc.signaling import register_signaling_events
+from middleware.rate_limiter import limiter  # ADD THIS
 
 app = Flask(__name__)
 app.config.from_object(Config)
+
+# Initialize rate limiter
+limiter.init_app(app)  # ADD THIS
 
 socketio = SocketIO(
     app,
@@ -62,4 +66,4 @@ if __name__ == "__main__":
         port=Config.PORT,
         debug=Config.DEBUG,
         allow_unsafe_werkzeug=True
-    )
+    )

--- a/config.py
+++ b/config.py
@@ -27,3 +27,6 @@ class Config:
     DATABASE_PATH = "database/vivaai.db"
 
     STUN_SERVER = "stun:stun.l.google.com:19302"
+    
+    # API Key for external service authentication
+    API_SECRET_KEY = os.environ.get("API_SECRET_KEY", os.environ.get("SECRET_KEY", "vivaai-api-secret-key"))

--- a/middleware/auth.py
+++ b/middleware/auth.py
@@ -1,0 +1,19 @@
+from functools import wraps
+from flask import request, jsonify, current_app
+import secrets
+
+
+def require_api_key(f):
+    """Decorator to require API key for protected endpoints"""
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        api_key = request.headers.get('X-API-Key')
+        expected_key = current_app.config.get('API_SECRET_KEY')
+        
+        if not api_key or not expected_key or not secrets.compare_digest(api_key, expected_key):
+            return jsonify({
+                "error": "Unauthorized",
+                "message": "Valid X-API-Key header required"
+            }), 401
+        return f(*args, **kwargs)
+    return decorated

--- a/middleware/rate_limiter.py
+++ b/middleware/rate_limiter.py
@@ -1,0 +1,14 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+# Initialize limiter (to be attached to app)
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["200 per day", "50 per hour"],
+    storage_uri="memory://"
+)
+
+# Rate limit presets
+AI_RATE_LIMIT = "10 per minute"      # AI endpoints: 10 requests/minute
+REPORT_RATE_LIMIT = "30 per minute"  # Report endpoints: 30 requests/minute
+CREATE_RATE_LIMIT = "5 per minute"   # Create interview: 5 requests/minute

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sarvamai>=0.1.0
 python-engineio>=4.9.0
 python-socketio>=5.11.0
 pydantic>=2.0.0
+Flask-Limiter==3.5.0

--- a/routes/ai_routes.py
+++ b/routes/ai_routes.py
@@ -7,11 +7,15 @@ from models.interview import save_report
 from utils.sanitization import sanitize_model_output
 from utils.validation import QuestionRequest, ReportRequest
 from pydantic import ValidationError
+from middleware.auth import require_api_key
+from middleware.rate_limiter import limiter, AI_RATE_LIMIT
 
 ai_bp = Blueprint("ai", __name__)
 
 
 @ai_bp.route("/api/ai/question", methods=["POST"])
+@require_api_key
+@limiter.limit(AI_RATE_LIMIT)
 def question():
     try:
         data = QuestionRequest(**request.get_json())
@@ -35,6 +39,8 @@ def question():
 
 
 @ai_bp.route("/api/ai/report", methods=["POST"])
+@require_api_key
+@limiter.limit(AI_RATE_LIMIT)
 def report():
     try:
         data = ReportRequest(**request.get_json())
@@ -58,6 +64,8 @@ def report():
 
 
 @ai_bp.route("/api/ai/transcribe", methods=["POST"])
+@require_api_key
+@limiter.limit(AI_RATE_LIMIT)
 def transcribe():
     file = request.files.get("audio")
     if not file:

--- a/routes/interview_routes.py
+++ b/routes/interview_routes.py
@@ -2,8 +2,11 @@ from flask import Blueprint, request, jsonify, render_template
 from models.interview import create_interview, save_answers, get_interview
 from utils.validation import CreateInterviewRequest, SaveAnswersRequest
 from pydantic import ValidationError
+from middleware.auth import require_api_key
+from middleware.rate_limiter import limiter, CREATE_RATE_LIMIT, REPORT_RATE_LIMIT
 import uuid
 import re
+import secrets
 
 interview_bp = Blueprint("interview", __name__)
 
@@ -30,13 +33,16 @@ def room_page(room_id):
 
 
 @interview_bp.route("/api/interview/create", methods=["POST"])
+@require_api_key
+@limiter.limit(CREATE_RATE_LIMIT)
 def create():
     try:
         data = CreateInterviewRequest(**request.get_json())
     except (ValidationError, TypeError) as e:
         return jsonify({"error": "Invalid input", "details": str(e)}), 400
 
-    room_id = data.room_id or str(uuid.uuid4())[:8]
+    # Generate longer room ID (16 chars instead of 8 for better security)
+    room_id = data.room_id or secrets.token_urlsafe(12)[:16]
     role = data.role
     candidate_name = data.candidate_name
     duration = data.duration
@@ -49,6 +55,8 @@ def create():
 
 
 @interview_bp.route("/api/interview/<room_id>", methods=["GET"])
+@require_api_key
+@limiter.limit(REPORT_RATE_LIMIT)
 def get(room_id):
     if not validate_room_id(room_id):
         return jsonify({"error": "Invalid room ID"}), 400
@@ -62,6 +70,8 @@ def get(room_id):
 
 
 @interview_bp.route("/api/interview/<room_id>/answers", methods=["POST"])
+@require_api_key
+@limiter.limit(REPORT_RATE_LIMIT)
 def save(room_id):
     if not validate_room_id(room_id):
         return jsonify({"error": "Invalid room ID"}), 400


### PR DESCRIPTION
## 🔐 Security Enhancement

### Changes Made

**Authentication:**
- ✅ Added `require_api_key` decorator for API key validation
- ✅ All API endpoints now require `X-API-Key` header

**Rate Limiting:**
- ✅ AI endpoints (`/api/ai/*`): 10 requests per minute
- ✅ Report endpoints: 30 requests per minute  
- ✅ Create interview: 5 requests per minute

**Security Improvements:**
- ✅ Improved room_id generation (16 chars instead of 8 using `secrets.token_urlsafe`)

### Files Changed
| File | Changes |
|------|---------|
| `middleware/auth.py` | New - API key validation |
| `middleware/rate_limiter.py` | New - Rate limit config |
| `app.py` | Added limiter initialization |
| `config.py` | Added `API_SECRET_KEY` |
| `requirements.txt` | Added `Flask-Limiter` |
| `routes/ai_routes.py` | Added auth + rate limits |
| `routes/interview_routes.py` | Added auth + rate limits + better room_id |

### Testing
- [x] Unauthorized requests return 401
- [x] Rate limit exceeded returns 429  
- [x] Valid API key allows access
- [x] Room ID now 16 chars (more secure)

### How to Test
1. Set `API_SECRET_KEY` in `.env`
2. Call API with header: `X-API-Key: your-secret-key`
3. Exceed 10 requests in 1 minute → get 429 error

