### PR TITLE
feat: add interview history dashboard and export functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from config import Config
 from models.interview import init_db
 from routes.ai_routes import ai_bp
 from routes.interview_routes import interview_bp
+from routes.history_routes import history_bp
 from webrtc.signaling import register_signaling_events
 
 app = Flask(__name__)
@@ -27,6 +28,7 @@ socketio = SocketIO(
 # Register blueprints
 app.register_blueprint(ai_bp)
 app.register_blueprint(interview_bp)
+app.register_blueprint(history_bp)
 
 # Register WebRTC signaling socket events
 register_signaling_events(socketio)

--- a/models/interview.py
+++ b/models/interview.py
@@ -99,3 +99,36 @@ def get_interview(room_id):
     conn.close()
 
     return interview
+
+
+def get_all_interviews():
+    conn = get_connection()
+    cur = conn.cursor()
+
+    cur.execute(
+        "SELECT id, room_id, candidate_name, role, duration, status, created_at, ended_at FROM interviews ORDER BY created_at DESC"
+    )
+
+    interviews = [dict(row) for row in cur.fetchall()]
+    conn.close()
+
+    return interviews
+
+
+def get_interviews_by_ids(room_ids):
+    if not room_ids:
+        return []
+
+    conn = get_connection()
+    cur = conn.cursor()
+
+    placeholders = ",".join("?" for _ in room_ids)
+    cur.execute(
+        f"SELECT * FROM interviews WHERE room_id IN ({placeholders})",
+        room_ids
+    )
+
+    interviews = [dict(row) for row in cur.fetchall()]
+    conn.close()
+
+    return interviews

--- a/routes/history_routes.py
+++ b/routes/history_routes.py
@@ -1,0 +1,147 @@
+import csv
+import io
+import json
+from flask import Blueprint, request, jsonify, render_template, Response
+from models.interview import get_all_interviews, get_interview, get_interviews_by_ids
+
+history_bp = Blueprint("history", __name__)
+
+
+@history_bp.route("/history")
+def history_page():
+    return render_template("history.html")
+
+
+@history_bp.route("/api/history", methods=["GET"])
+def list_interviews():
+    try:
+        interviews = get_all_interviews()
+        return jsonify({"interviews": interviews})
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+def _interview_to_export_dict(row):
+    """Convert a raw interview DB row (dict) into a clean export dict."""
+    qa_history = []
+    if row.get("qa_history"):
+        try:
+            qa_history = json.loads(row["qa_history"])
+        except (json.JSONDecodeError, TypeError):
+            qa_history = []
+
+    return {
+        "candidate_name": row.get("candidate_name", ""),
+        "role": row.get("role", ""),
+        "room_id": row.get("room_id", ""),
+        "duration_minutes": row.get("duration", ""),
+        "status": row.get("status", ""),
+        "created_at": row.get("created_at", ""),
+        "ended_at": row.get("ended_at", ""),
+        "qa_history": qa_history,
+        "report": row.get("report", ""),
+    }
+
+
+def _build_csv(interviews_export):
+    """Build a CSV string from a list of export dicts."""
+    output = io.StringIO()
+
+    # Determine max number of Q&A pairs across all interviews
+    max_qa = 0
+    for item in interviews_export:
+        qa_len = len(item.get("qa_history", []))
+        if qa_len > max_qa:
+            max_qa = qa_len
+
+    # Build header
+    header = ["candidate_name", "role", "room_id", "duration_minutes", "status", "created_at", "ended_at"]
+    for i in range(1, max_qa + 1):
+        header.append(f"question_{i}")
+        header.append(f"answer_{i}")
+    header.append("report")
+
+    writer = csv.writer(output)
+    writer.writerow(header)
+
+    for item in interviews_export:
+        row = [
+            item.get("candidate_name", ""),
+            item.get("role", ""),
+            item.get("room_id", ""),
+            item.get("duration_minutes", ""),
+            item.get("status", ""),
+            item.get("created_at", ""),
+            item.get("ended_at", ""),
+        ]
+        qa = item.get("qa_history", [])
+        for i in range(max_qa):
+            if i < len(qa):
+                row.append(qa[i].get("question", ""))
+                row.append(qa[i].get("answer", ""))
+            else:
+                row.append("")
+                row.append("")
+        row.append(item.get("report", ""))
+        writer.writerow(row)
+
+    return output.getvalue()
+
+
+@history_bp.route("/api/export/<room_id>", methods=["GET"])
+def export_single(room_id):
+    fmt = request.args.get("format", "json").lower()
+    interview = get_interview(room_id)
+
+    if not interview:
+        return jsonify({"error": "Interview not found"}), 404
+
+    export_data = _interview_to_export_dict(dict(interview))
+
+    if fmt == "csv":
+        csv_str = _build_csv([export_data])
+        return Response(
+            csv_str,
+            mimetype="text/csv",
+            headers={"Content-Disposition": f"attachment; filename=interview_{room_id}.csv"}
+        )
+
+    return Response(
+        json.dumps(export_data, indent=2, default=str),
+        mimetype="application/json",
+        headers={"Content-Disposition": f"attachment; filename=interview_{room_id}.json"}
+    )
+
+
+@history_bp.route("/api/export/batch", methods=["POST"])
+def export_batch():
+    fmt = request.args.get("format", "json").lower()
+    body = request.get_json(silent=True) or {}
+    room_ids = body.get("room_ids", [])
+
+    if not room_ids or not isinstance(room_ids, list):
+        return jsonify({"error": "Provide a non-empty list of room_ids"}), 400
+
+    # Sanitize: only allow alphanumeric + hyphen room IDs
+    import re
+    clean_ids = [rid for rid in room_ids if isinstance(rid, str) and re.match(r"^[A-Z0-9-]{1,50}$", rid, re.I)]
+
+    if not clean_ids:
+        return jsonify({"error": "No valid room IDs provided"}), 400
+
+    interviews = get_interviews_by_ids(clean_ids)
+    export_list = [_interview_to_export_dict(row) for row in interviews]
+
+    if fmt == "csv":
+        csv_str = _build_csv(export_list)
+        return Response(
+            csv_str,
+            mimetype="text/csv",
+            headers={"Content-Disposition": "attachment; filename=interviews_export.csv"}
+        )
+
+    return Response(
+        json.dumps(export_list, indent=2, default=str),
+        mimetype="application/json",
+        headers={"Content-Disposition": "attachment; filename=interviews_export.json"}
+    )

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -800,11 +800,430 @@ audio {
 ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 999px; }
 ::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
 
+/* ── History Page ────────────────────────────────────── */
+
+.history-hero {
+    padding: 48px 0 24px;
+    text-align: center;
+}
+
+/* ── Stats Row ───────────────────────────────────────── */
+.stats-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.stat-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 20px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    transition: all var(--transition);
+}
+
+.stat-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--accent), #8b5cf6);
+    opacity: 0;
+    transition: opacity var(--transition);
+}
+
+.stat-card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-glow);
+}
+
+.stat-card:hover::before { opacity: 1; }
+
+.stat-icon { font-size: 24px; margin-bottom: 8px; }
+
+.stat-value {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    line-height: 1.2;
+}
+
+.stat-unit {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-left: 2px;
+}
+
+.stat-label {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-top: 4px;
+}
+
+/* ── Controls Bar ────────────────────────────────────── */
+.history-controls {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+    padding: 16px 20px;
+}
+
+.history-controls-left {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    flex: 1;
+}
+
+.history-controls-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.search-wrapper {
+    position: relative;
+    flex: 1;
+    min-width: 200px;
+    max-width: 320px;
+}
+
+.search-icon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 14px;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.search-input {
+    padding-left: 38px !important;
+}
+
+.filter-select {
+    min-width: 150px;
+}
+
+.result-count {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+/* ── Batch Toolbar ───────────────────────────────────── */
+.batch-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 20px;
+    margin-bottom: 16px;
+    background: linear-gradient(135deg, rgba(59,130,246,.12), rgba(139,92,246,.08));
+    border-color: var(--accent);
+    gap: 12px;
+    flex-wrap: wrap;
+    opacity: 0;
+    max-height: 0;
+    overflow: hidden;
+    padding: 0 20px;
+    margin-bottom: 0;
+    border-width: 0;
+    transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.batch-toolbar.visible {
+    opacity: 1;
+    max-height: 80px;
+    padding: 12px 20px;
+    margin-bottom: 16px;
+    border-width: 1px;
+}
+
+.batch-toolbar-left { display: flex; align-items: center; gap: 12px; }
+.batch-toolbar-right { display: flex; align-items: center; gap: 8px; }
+
+.batch-count {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--accent-light);
+}
+
+/* ── Data Table ──────────────────────────────────────── */
+.history-table-wrap {
+    padding: 0;
+    overflow-x: auto;
+}
+
+.history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+}
+
+.history-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+
+.history-table th {
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 14px 16px;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+    user-select: none;
+}
+
+.history-table th.sortable {
+    cursor: pointer;
+    transition: color var(--transition);
+}
+
+.history-table th.sortable:hover {
+    color: var(--accent-light);
+}
+
+.sort-arrow {
+    font-size: 0.75rem;
+    margin-left: 4px;
+    color: var(--accent);
+}
+
+.history-table td {
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--border-light);
+    color: var(--text-secondary);
+    vertical-align: middle;
+}
+
+.history-table tr {
+    transition: background var(--transition);
+}
+
+.history-table tbody tr:hover {
+    background: var(--bg-hover);
+}
+
+.history-table tr.row-selected {
+    background: rgba(59,130,246,.08);
+}
+
+.history-table tr.row-selected:hover {
+    background: rgba(59,130,246,.14);
+}
+
+/* Columns */
+.col-check { width: 44px; text-align: center; }
+.col-name { min-width: 160px; }
+.col-role { min-width: 140px; }
+.col-duration { min-width: 80px; }
+.col-status { min-width: 100px; }
+.col-date { min-width: 140px; }
+.col-actions { min-width: 90px; text-align: center; }
+
+/* ── Candidate Cell ──────────────────────────────────── */
+.candidate-cell {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.candidate-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), #8b5cf6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: white;
+    flex-shrink: 0;
+}
+
+/* ── Badges ──────────────────────────────────────────── */
+.role-tag {
+    background: var(--bg-base);
+    border: 1px solid var(--border);
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.status-badge {
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
+}
+
+.badge-success {
+    background: rgba(16,185,129,.15);
+    border: 1px solid rgba(16,185,129,.3);
+    color: var(--success);
+}
+
+.badge-info {
+    background: rgba(59,130,246,.15);
+    border: 1px solid rgba(59,130,246,.3);
+    color: var(--accent-light);
+}
+
+.badge-muted {
+    background: rgba(148,163,184,.12);
+    border: 1px solid rgba(148,163,184,.2);
+    color: var(--text-muted);
+}
+
+/* ── Custom Checkbox ─────────────────────────────────── */
+.custom-check {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    position: relative;
+}
+
+.custom-check input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.custom-check .checkmark {
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    border: 2px solid var(--border);
+    background: var(--bg-base);
+    transition: all var(--transition);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.custom-check input:checked + .checkmark {
+    background: var(--accent);
+    border-color: var(--accent);
+}
+
+.custom-check input:checked + .checkmark::after {
+    content: '✓';
+    color: white;
+    font-size: 11px;
+    font-weight: 800;
+}
+
+.custom-check:hover .checkmark {
+    border-color: var(--accent-light);
+}
+
+/* ── Export Action Buttons ────────────────────────────── */
+.export-actions {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+}
+
+.btn-icon {
+    width: 34px;
+    height: 34px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border);
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all var(--transition);
+    padding: 0;
+    font-size: 0;
+}
+
+.btn-icon:hover {
+    border-color: var(--accent);
+    color: var(--accent-light);
+    background: var(--bg-hover);
+    transform: translateY(-1px);
+}
+
+.btn-icon-text {
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}
+
+/* ── Empty State ─────────────────────────────────────── */
+.empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 60px 24px;
+    margin-bottom: 32px;
+}
+
+.empty-icon {
+    font-size: 48px;
+    margin-bottom: 16px;
+    opacity: 0.7;
+}
+
+.empty-state h3 {
+    font-size: 1.2rem;
+    margin-bottom: 8px;
+    color: var(--text-primary);
+}
+
+.empty-state p {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    max-width: 340px;
+}
+
 /* ── Responsive ──────────────────────────────────────── */
 @media (max-width: 900px) {
     .interview-layout { grid-template-columns: 1fr; }
     .video-grid       { grid-template-columns: 1fr; }
     .features-grid    { grid-template-columns: 1fr; }
+    .stats-row        { grid-template-columns: repeat(2, 1fr); }
+    .history-controls { flex-direction: column; align-items: stretch; }
+    .history-controls-left { flex-direction: column; }
+    .search-wrapper { max-width: 100%; }
 }
 
 @media (max-width: 600px) {
@@ -813,4 +1232,11 @@ audio {
     .hero { padding: 48px 0 32px; }
     .control-bar { gap: 8px; }
     .btn { padding: 9px 16px; font-size: 0.825rem; }
+    .stats-row { grid-template-columns: 1fr 1fr; gap: 10px; }
+    .stat-card { padding: 14px; }
+    .stat-value { font-size: 1.5rem; }
+    .history-table { font-size: 0.8rem; }
+    .history-table th, .history-table td { padding: 10px 10px; }
+    .batch-toolbar { flex-direction: column; text-align: center; }
+    .batch-toolbar-right { justify-content: center; }
 }

--- a/templates/history.html
+++ b/templates/history.html
@@ -1,0 +1,473 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        // Apply saved theme on load
+        (function () {
+            const saved = localStorage.getItem("vivaai-theme") || "dark";
+            document.documentElement.setAttribute("data-theme", saved);
+        })();
+    </script>
+    <meta name="description"
+        content="VivaAI Interview History — View, search, and export your past AI interview sessions and analytics.">
+    <title>VivaAI — Interview History & Export</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+
+<body>
+
+    <header class="header">
+        <a class="logo" href="/">
+            <div class="logo-icon">🤖</div>
+            <span class="logo-text">VivaAI</span>
+        </a>
+        <div style="display:flex; align-items:center; gap:10px;">
+            <a href="/" class="btn btn-ghost btn-sm" style="text-decoration:none;">🏠 Home</a>
+            <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle theme">🌙</button>
+        </div>
+    </header>
+
+    <main class="container">
+
+        <!-- Page Hero -->
+        <section class="history-hero fade-in">
+            <div class="hero-eyebrow">
+                <span>✦</span> Interview Analytics
+            </div>
+            <h1 class="hero-title" style="font-size: clamp(1.6rem, 4vw, 2.5rem); margin-bottom: 10px;">Interview History</h1>
+            <p class="hero-subtitle" style="margin-bottom: 28px; font-size: 1rem;">
+                Browse all your past AI interview sessions, review results, and export data.
+            </p>
+        </section>
+
+        <!-- Stats Row -->
+        <div class="stats-row fade-in" id="statsRow">
+            <div class="stat-card">
+                <div class="stat-icon">📋</div>
+                <div class="stat-value" id="statTotal">0</div>
+                <div class="stat-label">Total Interviews</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-icon">✅</div>
+                <div class="stat-value" id="statCompleted">0</div>
+                <div class="stat-label">Completed</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-icon">⏱️</div>
+                <div class="stat-value" id="statAvgDuration">0<span class="stat-unit">min</span></div>
+                <div class="stat-label">Avg Duration</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-icon">🎯</div>
+                <div class="stat-value" id="statRoles">0</div>
+                <div class="stat-label">Unique Roles</div>
+            </div>
+        </div>
+
+        <!-- Controls Bar -->
+        <div class="history-controls card fade-in">
+            <div class="history-controls-left">
+                <div class="search-wrapper">
+                    <span class="search-icon">🔍</span>
+                    <input class="form-input search-input" id="searchInput" type="text"
+                        placeholder="Search by candidate name…" autocomplete="off">
+                </div>
+                <select class="form-input filter-select" id="filterRole">
+                    <option value="">All Roles</option>
+                </select>
+                <select class="form-input filter-select" id="filterStatus">
+                    <option value="">All Status</option>
+                    <option value="completed">Completed</option>
+                    <option value="active">Active</option>
+                    <option value="ended">Ended</option>
+                </select>
+            </div>
+            <div class="history-controls-right">
+                <span class="result-count" id="resultCount">0 interviews</span>
+            </div>
+        </div>
+
+        <!-- Batch Toolbar -->
+        <div class="batch-toolbar card" id="batchToolbar">
+            <div class="batch-toolbar-left">
+                <span class="batch-count" id="batchCount">0 selected</span>
+            </div>
+            <div class="batch-toolbar-right">
+                <button class="btn btn-primary btn-sm" id="batchExportJson" onclick="batchExport('json')">
+                    📥 Export JSON
+                </button>
+                <button class="btn btn-success btn-sm" id="batchExportCsv" onclick="batchExport('csv')">
+                    📄 Export CSV
+                </button>
+                <button class="btn btn-ghost btn-sm" onclick="clearSelection()">✕ Clear</button>
+            </div>
+        </div>
+
+        <!-- Data Table -->
+        <div class="history-table-wrap card fade-in" id="tableWrap">
+            <table class="history-table" id="historyTable">
+                <thead>
+                    <tr>
+                        <th class="col-check">
+                            <label class="custom-check">
+                                <input type="checkbox" id="selectAll" onchange="toggleSelectAll()">
+                                <span class="checkmark"></span>
+                            </label>
+                        </th>
+                        <th class="col-name sortable" data-sort="candidate_name" onclick="sortTable('candidate_name')">
+                            Candidate <span class="sort-arrow" id="sort_candidate_name"></span>
+                        </th>
+                        <th class="col-role sortable" data-sort="role" onclick="sortTable('role')">
+                            Role <span class="sort-arrow" id="sort_role"></span>
+                        </th>
+                        <th class="col-duration sortable" data-sort="duration" onclick="sortTable('duration')">
+                            Duration <span class="sort-arrow" id="sort_duration"></span>
+                        </th>
+                        <th class="col-status sortable" data-sort="status" onclick="sortTable('status')">
+                            Status <span class="sort-arrow" id="sort_status"></span>
+                        </th>
+                        <th class="col-date sortable" data-sort="created_at" onclick="sortTable('created_at')">
+                            Date <span class="sort-arrow" id="sort_created_at"></span>
+                        </th>
+                        <th class="col-actions">Export</th>
+                    </tr>
+                </thead>
+                <tbody id="tableBody">
+                </tbody>
+            </table>
+        </div>
+
+        <!-- Empty State -->
+        <div class="empty-state card fade-in" id="emptyState" style="display:none;">
+            <div class="empty-icon">📭</div>
+            <h3>No Interviews Yet</h3>
+            <p>Start your first AI interview session and it'll show up here.</p>
+            <a href="/" class="btn btn-primary" style="margin-top:16px; text-decoration:none;">🚀 Start Interview</a>
+        </div>
+
+        <!-- No Results State -->
+        <div class="empty-state card fade-in" id="noResults" style="display:none;">
+            <div class="empty-icon">🔍</div>
+            <h3>No Results Found</h3>
+            <p>Try adjusting your search or filter criteria.</p>
+        </div>
+
+    </main>
+
+    <script>
+        // ── Theme Toggle ────────────────────────────────────
+        function toggleTheme() {
+            const html = document.documentElement;
+            const btn = document.getElementById("themeToggle");
+            const isDark = html.getAttribute("data-theme") !== "light";
+            html.setAttribute("data-theme", isDark ? "light" : "dark");
+            btn.textContent = isDark ? "☀️" : "🌙";
+            localStorage.setItem("vivaai-theme", isDark ? "light" : "dark");
+        }
+        // Set initial icon
+        (function () {
+            const saved = localStorage.getItem("vivaai-theme") || "dark";
+            const btn = document.getElementById("themeToggle");
+            if (btn) btn.textContent = saved === "light" ? "☀️" : "🌙";
+        })();
+
+        // ── State ───────────────────────────────────────────
+        let allInterviews = [];
+        let filteredInterviews = [];
+        let selectedIds = new Set();
+        let currentSort = { key: "created_at", dir: "desc" };
+
+        // ── Init ────────────────────────────────────────────
+        document.addEventListener("DOMContentLoaded", async () => {
+            await loadInterviews();
+            document.getElementById("searchInput").addEventListener("input", applyFilters);
+            document.getElementById("filterRole").addEventListener("change", applyFilters);
+            document.getElementById("filterStatus").addEventListener("change", applyFilters);
+        });
+
+        async function loadInterviews() {
+            try {
+                const res = await fetch("/api/history");
+                const data = await res.json();
+                allInterviews = data.interviews || [];
+                populateRoleFilter();
+                applyFilters();
+                updateStats();
+            } catch (err) {
+                console.error("Failed to load interviews:", err);
+            }
+        }
+
+        // ── Stats ───────────────────────────────────────────
+        function updateStats() {
+            const total = allInterviews.length;
+            const completed = allInterviews.filter(i => i.status === "completed").length;
+            const durations = allInterviews.map(i => i.duration || 0);
+            const avgDur = total > 0 ? Math.round(durations.reduce((a, b) => a + b, 0) / total) : 0;
+            const roles = new Set(allInterviews.map(i => i.role)).size;
+
+            animateCounter("statTotal", total);
+            animateCounter("statCompleted", completed);
+            animateCounter("statAvgDuration", avgDur, "min");
+            animateCounter("statRoles", roles);
+        }
+
+        function animateCounter(id, target, unit) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            let current = 0;
+            const step = Math.max(1, Math.ceil(target / 30));
+            const interval = setInterval(() => {
+                current = Math.min(current + step, target);
+                el.innerHTML = current + (unit ? `<span class="stat-unit">${unit}</span>` : "");
+                if (current >= target) clearInterval(interval);
+            }, 30);
+        }
+
+        // ── Filters ─────────────────────────────────────────
+        function populateRoleFilter() {
+            const select = document.getElementById("filterRole");
+            const roles = [...new Set(allInterviews.map(i => i.role))].sort();
+            // Keep first option
+            select.innerHTML = '<option value="">All Roles</option>';
+            roles.forEach(r => {
+                const opt = document.createElement("option");
+                opt.value = r;
+                opt.textContent = r;
+                select.appendChild(opt);
+            });
+        }
+
+        function applyFilters() {
+            const search = document.getElementById("searchInput").value.toLowerCase().trim();
+            const roleFilter = document.getElementById("filterRole").value;
+            const statusFilter = document.getElementById("filterStatus").value;
+
+            filteredInterviews = allInterviews.filter(i => {
+                const matchName = !search || (i.candidate_name || "").toLowerCase().includes(search);
+                const matchRole = !roleFilter || i.role === roleFilter;
+                const matchStatus = !statusFilter || i.status === statusFilter;
+                return matchName && matchRole && matchStatus;
+            });
+
+            // Apply current sort
+            sortData();
+            renderTable();
+        }
+
+        // ── Sorting ─────────────────────────────────────────
+        function sortTable(key) {
+            if (currentSort.key === key) {
+                currentSort.dir = currentSort.dir === "asc" ? "desc" : "asc";
+            } else {
+                currentSort.key = key;
+                currentSort.dir = "asc";
+            }
+
+            // Update arrows
+            document.querySelectorAll(".sort-arrow").forEach(el => el.textContent = "");
+            const arrow = document.getElementById("sort_" + key);
+            if (arrow) arrow.textContent = currentSort.dir === "asc" ? "↑" : "↓";
+
+            sortData();
+            renderTable();
+        }
+
+        function sortData() {
+            const { key, dir } = currentSort;
+            filteredInterviews.sort((a, b) => {
+                let va = a[key] ?? "";
+                let vb = b[key] ?? "";
+                if (typeof va === "number" && typeof vb === "number") {
+                    return dir === "asc" ? va - vb : vb - va;
+                }
+                va = String(va).toLowerCase();
+                vb = String(vb).toLowerCase();
+                if (va < vb) return dir === "asc" ? -1 : 1;
+                if (va > vb) return dir === "asc" ? 1 : -1;
+                return 0;
+            });
+        }
+
+        // ── Render Table ────────────────────────────────────
+        function renderTable() {
+            const tbody = document.getElementById("tableBody");
+            const tableWrap = document.getElementById("tableWrap");
+            const emptyState = document.getElementById("emptyState");
+            const noResults = document.getElementById("noResults");
+            const resultCount = document.getElementById("resultCount");
+
+            resultCount.textContent = `${filteredInterviews.length} interview${filteredInterviews.length !== 1 ? "s" : ""}`;
+
+            // Show/hide states
+            if (allInterviews.length === 0) {
+                tableWrap.style.display = "none";
+                emptyState.style.display = "flex";
+                noResults.style.display = "none";
+                return;
+            }
+
+            if (filteredInterviews.length === 0) {
+                tableWrap.style.display = "none";
+                emptyState.style.display = "none";
+                noResults.style.display = "flex";
+                return;
+            }
+
+            tableWrap.style.display = "block";
+            emptyState.style.display = "none";
+            noResults.style.display = "none";
+
+            tbody.innerHTML = "";
+
+            filteredInterviews.forEach((interview, idx) => {
+                const tr = document.createElement("tr");
+                tr.className = selectedIds.has(interview.room_id) ? "row-selected" : "";
+                tr.setAttribute("data-room", interview.room_id);
+
+                const statusClass = interview.status === "completed" ? "badge-success"
+                    : interview.status === "active" ? "badge-info" : "badge-muted";
+
+                const dateStr = interview.created_at ? formatDate(interview.created_at) : "—";
+
+                tr.innerHTML = `
+                    <td class="col-check">
+                        <label class="custom-check">
+                            <input type="checkbox" onchange="toggleSelect('${interview.room_id}')"
+                                ${selectedIds.has(interview.room_id) ? "checked" : ""}>
+                            <span class="checkmark"></span>
+                        </label>
+                    </td>
+                    <td class="col-name">
+                        <div class="candidate-cell">
+                            <div class="candidate-avatar">${(interview.candidate_name || "?")[0].toUpperCase()}</div>
+                            <span>${escapeHtml(interview.candidate_name || "Unknown")}</span>
+                        </div>
+                    </td>
+                    <td class="col-role"><span class="role-tag">${escapeHtml(interview.role || "—")}</span></td>
+                    <td class="col-duration">${interview.duration || 0} min</td>
+                    <td class="col-status"><span class="status-badge ${statusClass}">${escapeHtml(interview.status || "unknown")}</span></td>
+                    <td class="col-date">${dateStr}</td>
+                    <td class="col-actions">
+                        <div class="export-actions">
+                            <button class="btn-icon" title="Export JSON" onclick="exportSingle('${interview.room_id}', 'json')">
+                                <span class="btn-icon-text">{ }</span>
+                            </button>
+                            <button class="btn-icon" title="Export CSV" onclick="exportSingle('${interview.room_id}', 'csv')">
+                                <span class="btn-icon-text">CSV</span>
+                            </button>
+                        </div>
+                    </td>
+                `;
+                tbody.appendChild(tr);
+            });
+
+            updateBatchToolbar();
+        }
+
+        // ── Selection ───────────────────────────────────────
+        function toggleSelect(roomId) {
+            if (selectedIds.has(roomId)) {
+                selectedIds.delete(roomId);
+            } else {
+                selectedIds.add(roomId);
+            }
+            updateBatchToolbar();
+            // Update row highlight
+            const row = document.querySelector(`tr[data-room="${roomId}"]`);
+            if (row) row.className = selectedIds.has(roomId) ? "row-selected" : "";
+
+            // Update select-all checkbox
+            const selectAll = document.getElementById("selectAll");
+            if (selectAll) {
+                selectAll.checked = filteredInterviews.length > 0 && filteredInterviews.every(i => selectedIds.has(i.room_id));
+            }
+        }
+
+        function toggleSelectAll() {
+            const selectAll = document.getElementById("selectAll");
+            if (selectAll.checked) {
+                filteredInterviews.forEach(i => selectedIds.add(i.room_id));
+            } else {
+                filteredInterviews.forEach(i => selectedIds.delete(i.room_id));
+            }
+            renderTable();
+        }
+
+        function clearSelection() {
+            selectedIds.clear();
+            const selectAll = document.getElementById("selectAll");
+            if (selectAll) selectAll.checked = false;
+            renderTable();
+        }
+
+        function updateBatchToolbar() {
+            const toolbar = document.getElementById("batchToolbar");
+            const count = document.getElementById("batchCount");
+            if (selectedIds.size > 0) {
+                toolbar.classList.add("visible");
+                count.textContent = `${selectedIds.size} selected`;
+            } else {
+                toolbar.classList.remove("visible");
+            }
+        }
+
+        // ── Export ───────────────────────────────────────────
+        function exportSingle(roomId, format) {
+            window.location.href = `/api/export/${roomId}?format=${format}`;
+        }
+
+        async function batchExport(format) {
+            const roomIds = [...selectedIds];
+            if (roomIds.length === 0) return;
+
+            try {
+                const res = await fetch(`/api/export/batch?format=${format}`, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ room_ids: roomIds })
+                });
+
+                if (!res.ok) throw new Error("Export failed");
+
+                const blob = await res.blob();
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download = `interviews_export.${format}`;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+            } catch (err) {
+                console.error("Batch export failed:", err);
+                alert("Export failed. Please try again.");
+            }
+        }
+
+        // ── Helpers ──────────────────────────────────────────
+        function formatDate(dateStr) {
+            try {
+                const d = new Date(dateStr);
+                return d.toLocaleDateString("en-IN", {
+                    year: "numeric", month: "short", day: "numeric",
+                    hour: "2-digit", minute: "2-digit"
+                });
+            } catch {
+                return dateStr;
+            }
+        }
+
+        function escapeHtml(str) {
+            const div = document.createElement("div");
+            div.textContent = str;
+            return div.innerHTML;
+        }
+    </script>
+
+</body>
+
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -205,6 +205,7 @@ function toggleTheme() {
             <span class="logo-text">VivaAI</span>
         </a>
         <div style="display:flex; align-items:center; gap:10px;">
+    <a href="/history" class="btn btn-ghost btn-sm" style="text-decoration:none;">📊 History</a>
     <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle theme">🌙</button>
     <span class="header-badge">Beta</span>
 </div>

--- a/templates/interview_room.html
+++ b/templates/interview_room.html
@@ -71,6 +71,7 @@
             <span class="logo-text">VivaAI</span>
         </a>
         <div style="display:flex; align-items:center; gap:12px;">
+    <a href="/history" class="btn btn-ghost btn-sm" style="text-decoration:none; font-size:0.75rem;">📊 History</a>
     <button class="theme-toggle" id="themeToggle" onclick="toggleTheme()" title="Toggle theme">🌙</button>
     <span class="meta-badge" id="roleDisplay">{{ interview.role if interview else 'Interview' }}</span>
    <span class="timer-display" id="timer">{{ '%02d:00' % (interview.duration if interview else 10) }}</span>


### PR DESCRIPTION
### Key Changes:
*   **Backend / DB:** Added queries in `models/interview.py` to retrieve all interviews and fetch specific interviews by IDs for batch processing.
*   **API Routes:** Created a new `history_bp` blueprint with endpoints to list history and export data.
*   **Export Functionality:** Added the ability to download interview data (including Q&A history and generated reports) in both **JSON** and dynamically formatted **CSV** formats. Supports single exports and batch exports.
*   **UI/Frontend:**
    *   Added a premium `history.html` dashboard featuring animated stat cards, a sortable data table, and search/filter controls.
    *   Added a floating action bar for batch operations.
    *   Updated navigation headers in existing pages to link to the new History page.