### PR TITLE
(#25) issue - API key optional auth + 10/min rate limit on AI routes 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 SECRET_KEY=vivaai-super-secret-key-change-me
+# Optional. If set, browser / API clients must send header: X-API-Key: <same value>
+# for protected routes (AI + interview writes). Leave empty to disable enforcement locally.
+VIVAAI_API_KEY=
 SARVAM_API_KEY=your_sarvam_api_key_here
 SARVAM_CHAT_MODEL=sarvam-m
 SARVAM_STT_MODEL=saarika:v2.5

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from flask import Flask, render_template
 from flask_socketio import SocketIO
 
 from config import Config
+from limiter_ext import limiter
 from models.interview import init_db
 from routes.ai_routes import ai_bp
 from routes.interview_routes import interview_bp
@@ -15,6 +16,8 @@ from webrtc.signaling import register_signaling_events
 
 app = Flask(__name__)
 app.config.from_object(Config)
+
+limiter.init_app(app)
 
 socketio = SocketIO(
     app,
@@ -32,6 +35,12 @@ app.register_blueprint(history_bp)
 
 # Register WebRTC signaling socket events
 register_signaling_events(socketio)
+
+
+@app.context_processor
+def inject_client_config():
+    """Expose optional API key to templates for X-API-Key header (same-origin limitation applies)."""
+    return {"vivaai_api_key": app.config.get("VIVAAI_API_KEY") or ""}
 
 
 @app.route("/")
@@ -64,4 +73,4 @@ if __name__ == "__main__":
         port=Config.PORT,
         debug=Config.DEBUG,
         allow_unsafe_werkzeug=True
-    )
+    )

--- a/config.py
+++ b/config.py
@@ -7,6 +7,10 @@ load_dotenv()
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY", "vivaai-secret")
 
+    # Optional. When set, state-changing API routes require matching X-API-Key header.
+    # Use a value distinct from SECRET_KEY; never commit real keys.
+    VIVAAI_API_KEY = os.environ.get("VIVAAI_API_KEY", "").strip()
+
     SARVAM_API_KEY = os.environ.get("SARVAM_API_KEY", "")
     SARVAM_CHAT_MODEL = os.environ.get("SARVAM_CHAT_MODEL", "sarvam-m")
     SARVAM_STT_MODEL = os.environ.get("SARVAM_STT_MODEL", "saarika:v2.5")

--- a/limiter_ext.py
+++ b/limiter_ext.py
@@ -1,0 +1,5 @@
+"""Shared Flask-Limiter instance (initialized in app.py)."""
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address, default_limits=[])

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sarvamai>=0.1.0
 python-engineio>=4.9.0
 python-socketio>=5.11.0
 pydantic>=2.0.0
+Flask-Limiter>=3.8.0

--- a/routes/ai_routes.py
+++ b/routes/ai_routes.py
@@ -3,7 +3,9 @@ from ai.question_engine import generate_question
 from ai.tts_engine import generate_voice
 from ai.report_engine import generate_report
 from ai.stt_engine import transcribe_audio
+from limiter_ext import limiter
 from models.interview import save_report
+from utils.auth import require_api_key
 from utils.sanitization import sanitize_model_output
 from utils.validation import QuestionRequest, ReportRequest
 from pydantic import ValidationError
@@ -12,6 +14,8 @@ ai_bp = Blueprint("ai", __name__)
 
 
 @ai_bp.route("/api/ai/question", methods=["POST"])
+@limiter.limit("10 per minute")
+@require_api_key
 def question():
     try:
         data = QuestionRequest(**request.get_json())
@@ -35,6 +39,8 @@ def question():
 
 
 @ai_bp.route("/api/ai/report", methods=["POST"])
+@limiter.limit("10 per minute")
+@require_api_key
 def report():
     try:
         data = ReportRequest(**request.get_json())
@@ -58,6 +64,8 @@ def report():
 
 
 @ai_bp.route("/api/ai/transcribe", methods=["POST"])
+@limiter.limit("10 per minute")
+@require_api_key
 def transcribe():
     file = request.files.get("audio")
     if not file:

--- a/routes/interview_routes.py
+++ b/routes/interview_routes.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify, render_template
 from models.interview import create_interview, save_answers, get_interview
+from utils.auth import require_api_key
 from utils.validation import CreateInterviewRequest, SaveAnswersRequest
 from pydantic import ValidationError
 import uuid
@@ -30,6 +31,7 @@ def room_page(room_id):
 
 
 @interview_bp.route("/api/interview/create", methods=["POST"])
+@require_api_key
 def create():
     try:
         data = CreateInterviewRequest(**request.get_json())
@@ -62,6 +64,7 @@ def get(room_id):
 
 
 @interview_bp.route("/api/interview/<room_id>/answers", methods=["POST"])
+@require_api_key
 def save(room_id):
     if not validate_room_id(room_id):
         return jsonify({"error": "Invalid room ID"}), 400

--- a/scripts/_issue25_rate_subprocess.py
+++ b/scripts/_issue25_rate_subprocess.py
@@ -1,0 +1,29 @@
+"""Subprocess helper: fresh Limiter state for 10/min test."""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from app import app  # noqa: E402
+from models.interview import init_db  # noqa: E402
+
+
+def main() -> None:
+    init_db()
+    app.config["VIVAAI_API_KEY"] = "k"
+    body = {"role": "Software Developer", "answer": None, "question_history": []}
+    c = app.test_client()
+    with patch("routes.ai_routes.generate_question", return_value="Q"):
+        with patch("routes.ai_routes.generate_voice", return_value="/x"):
+            for i in range(10):
+                r = c.post("/api/ai/question", json=body, headers={"X-API-Key": "k"})
+                assert r.status_code == 200, (i, r.status_code, r.get_data(as_text=True)[:200])
+            r = c.post("/api/ai/question", json=body, headers={"X-API-Key": "k"})
+            assert r.status_code == 429, "11th request should be rate limited"
+
+
+if __name__ == "__main__":
+    main()
+    print("OK: 429 on 11th AI request in 1 minute")

--- a/scripts/verify_issue_25.py
+++ b/scripts/verify_issue_25.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Verify Issue #25 acceptance without calling external AI APIs.
+Run from repo root: python scripts/verify_issue_25.py
+"""
+import subprocess
+import uuid
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import app  # noqa: E402
+from models.interview import init_db  # noqa: E402
+
+
+def main() -> int:
+    init_db()
+    client = app.test_client()
+    body = {
+        "role": "Software Developer",
+        "answer": None,
+        "question_history": [],
+    }
+
+    app.config["VIVAAI_API_KEY"] = ""
+    rid1 = uuid.uuid4().hex[:8].upper()
+    with patch("routes.ai_routes.generate_question", return_value="Hello?"):
+        with patch("routes.ai_routes.generate_voice", return_value="/static/x.wav"):
+            r = client.post("/api/interview/create", json={
+                "room_id": rid1,
+                "role": "Software Developer",
+                "candidate_name": "Test",
+                "duration": 10,
+            })
+            assert r.status_code != 401, "mutating route should not require key when unset"
+
+            r = client.post("/api/ai/question", json=body)
+            assert r.status_code != 401, f"expected not 401 when key unset, got {r.status_code}"
+
+    print("OK: no 401 when VIVAAI_API_KEY empty (interview create + AI question)")
+
+    app.config["VIVAAI_API_KEY"] = "test-secret-key-issue25"
+    r = client.post("/api/ai/question", json=body)
+    assert r.status_code == 401, r.status_code
+    r = client.post("/api/ai/question", json=body, headers={"X-API-Key": "nope"})
+    assert r.status_code == 401
+    print("OK: 401 without / with wrong X-API-Key")
+
+    with patch("routes.ai_routes.generate_question", return_value="Hello?"):
+        with patch("routes.ai_routes.generate_voice", return_value="/static/x.wav"):
+            r = client.post(
+                "/api/ai/question",
+                json=body,
+                headers={"X-API-Key": "test-secret-key-issue25"},
+            )
+            assert r.status_code == 200, (r.status_code, r.get_data(as_text=True)[:400])
+
+    rid2 = uuid.uuid4().hex[:8].upper()
+    r = client.post(
+        "/api/interview/create",
+        json={
+            "room_id": rid2,
+            "role": "Software Developer",
+            "candidate_name": "T",
+            "duration": 10,
+        },
+        headers={"X-API-Key": "test-secret-key-issue25"},
+    )
+    assert r.status_code == 200, r.get_data(as_text=True)
+    print("OK: 200 with valid X-API-Key on AI + interview create")
+
+    rc = subprocess.call(
+        [sys.executable, str(ROOT / "scripts" / "_issue25_rate_subprocess.py")],
+        cwd=str(ROOT),
+    )
+    assert rc == 0
+    print("\nAll Issue #25 verification checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,0 +1,11 @@
+/**
+ * Adds X-API-Key when VIVAAI_API_KEY is set server-side (injected as __VIVAAI_API_KEY__).
+ * For multipart/form-data requests, omit Content-Type so the browser sets the boundary.
+ */
+function vivaaiApiHeaders(extra) {
+    const h = Object.assign({}, extra || {});
+    if (typeof window.__VIVAAI_API_KEY__ === "string" && window.__VIVAAI_API_KEY__.length > 0) {
+        h["X-API-Key"] = window.__VIVAAI_API_KEY__;
+    }
+    return h;
+}

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -48,6 +48,7 @@ async function transcribeRecordedAudio(audioBlob) {
 
         const response = await fetch("/api/ai/transcribe", {
             method: "POST",
+            headers: vivaaiApiHeaders({}),
             body: formData
         });
 

--- a/static/js/interview.js
+++ b/static/js/interview.js
@@ -90,7 +90,7 @@ async function fetchNextQuestion(answerText) {
     try {
         const response = await fetch("/api/ai/question", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: vivaaiApiHeaders({ "Content-Type": "application/json" }),
             body: JSON.stringify({
                 role: roleValue,
                 answer: answerText,
@@ -203,7 +203,7 @@ async function endInterview() {
     try {
         const response = await fetch("/api/ai/report", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: vivaaiApiHeaders({ "Content-Type": "application/json" }),
             body: JSON.stringify({
                 role: roleValue,
                 qa_history: questionHistory,

--- a/templates/create_interview.html
+++ b/templates/create_interview.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>window.__VIVAAI_API_KEY__ = {{ (vivaai_api_key or '')|tojson }};</script>
+    <script src="/static/js/api.js"></script>
     <meta name="description" content="VivaAI — Create a new AI interview session">
     <title>VivaAI — Create Interview</title>
     <link rel="stylesheet" href="/static/css/style.css">
@@ -87,7 +89,7 @@
             try {
                 const res = await fetch("/api/interview/create", {
                     method: "POST",
-                    headers: { "Content-Type": "application/json" },
+                    headers: vivaaiApiHeaders({ "Content-Type": "application/json" }),
                     body: JSON.stringify({ room_id: roomId, role, candidate_name: name })
                 });
                 const data = await res.json();

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>window.__VIVAAI_API_KEY__ = {{ (vivaai_api_key or '')|tojson }};</script>
+    <script src="/static/js/api.js"></script>
     <script>
         // Apply saved theme on load
         (function() {
@@ -153,7 +155,7 @@ el.textContent = icon + msg;
             try {
                 const res = await fetch("/api/interview/create", {
                     method: "POST",
-                    headers: { "Content-Type": "application/json" },
+                    headers: vivaaiApiHeaders({ "Content-Type": "application/json" }),
                     body: JSON.stringify({ room_id: roomId, role, candidate_name: name, duration })
                 });
 

--- a/templates/interview_room.html
+++ b/templates/interview_room.html
@@ -240,6 +240,8 @@
     </script>
 
     <!-- Load scripts in correct order -->
+    <script>window.__VIVAAI_API_KEY__ = {{ (vivaai_api_key or '')|tojson }};</script>
+    <script src="/static/js/api.js"></script>
     <script src="/static/js/socket.js"></script>
     <script src="/static/js/webrtc.js"></script>
     <script src="/static/js/audio.js"></script>

--- a/utils/auth.py
+++ b/utils/auth.py
@@ -1,0 +1,27 @@
+import secrets
+from functools import wraps
+
+from flask import current_app, jsonify, request
+
+
+def require_api_key(f):
+    """
+    Require a valid X-API-Key header when VIVAAI_API_KEY is set in config.
+    If unset, enforcement is skipped so local dev works without a key.
+    """
+
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        expected = (current_app.config.get("VIVAAI_API_KEY") or "").strip()
+        if not expected:
+            return f(*args, **kwargs)
+
+        provided = request.headers.get("X-API-Key", "")
+        if not secrets.compare_digest(
+            provided.encode("utf-8"),
+            expected.encode("utf-8"),
+        ):
+            return jsonify({"error": "Unauthorized"}), 401
+        return f(*args, **kwargs)
+
+    return decorated


### PR DESCRIPTION
👉 Summary :
Closes https://github.com/PrakharDoneria/VivaAI/issues/25

Approach 👇

- > Read [Issue #25](https://github.com/PrakharDoneria/VivaAI/issues/25) and mapped ai_routes + interview_routes; skimmed history_routes (still guessable by room_id) but kept scope to the issue files unless maintainers want more.

- > Flask-Limiter on /api/ai/* → 429 at 10/min/IP; require_api_key on mutating routes when VIVAAI_API_KEY is set.
Called out the browser tradeoff: a shared key in-page is a light gate, not strong secrecy..

Decisions 👇

- VIVAAI_API_KEY instead of SECRET_KEY (signing vs API auth; easier rotation).
secrets.compare_digest for the header check.

- Multipart STT: only add X-API-Key, don’t force Content-Type on FormData.

- Optional key: empty env → no auth enforcement → easier python app.py locally.
scripts/verify_issue_25.py: mocks AI so 401 / 429 are testable without Sarvam.

👉 How to verify
```bash
pip install -r requirements.txt
python scripts/verify_issue_25.py
```
I followed the issue’s intent with Flask-Limiter + X-API-Key, but split the API secret into VIVAAI_API_KEY instead of reusing SECRET_KEY, added optional enforcement for local dev, and shipped a small script to verify 401/429 without hitting Sarvam.
