### PR TITLE
Add WebRTC room access validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,11 +1,13 @@
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv()
+BASE_DIR = Path(__file__).resolve().parent
+load_dotenv(BASE_DIR / ".env")
 
 
 class Config:
-    SECRET_KEY = os.environ.get("SECRET_KEY", "vivaai-secret")
+    SECRET_KEY = os.environ.get("SECRET_KEY") or os.environ.get("FLASK_SECRET_KEY", "vivaai-secret")
 
     # Optional. When set, state-changing API routes require matching X-API-Key header.
     # Use a value distinct from SECRET_KEY; never commit real keys.

--- a/scripts/verify_webrtc_room_guards.py
+++ b/scripts/verify_webrtc_room_guards.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Verify WebRTC signaling room guardrails.
+Run from repo root: python scripts/verify_webrtc_room_guards.py
+"""
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app import app, socketio  # noqa: E402
+from models.interview import create_interview, end_interview, init_db  # noqa: E402
+
+
+def assert_event(client, event_name, expected_message=None):
+    events = client.get_received()
+    for event in events:
+        if event["name"] != event_name:
+            continue
+        if expected_message is not None:
+            payload = event["args"][0] if event["args"] else {}
+            assert payload.get("message") == expected_message, payload
+        return
+    raise AssertionError(f"Expected event {event_name!r}, got {events!r}")
+
+
+def main() -> int:
+    init_db()
+    flask_client = app.test_client()
+
+    active_room = uuid.uuid4().hex[:8].upper()
+    create_interview(active_room, "Engineer", "Candidate", 10)
+
+    client1 = socketio.test_client(app, flask_test_client=flask_client)
+    client2 = socketio.test_client(app, flask_test_client=flask_client)
+    client3 = socketio.test_client(app, flask_test_client=flask_client)
+
+    client1.emit("join-room", {"room": active_room})
+    assert_event(client1, "room-joined")
+
+    client2.emit("join-room", {"room": active_room})
+    assert_event(client2, "room-joined")
+
+    client3.emit("join-room", {"room": active_room})
+    assert_event(client3, "error", "Room is full")
+    print("OK: third participant is rejected from active room")
+
+    ended_room = uuid.uuid4().hex[:8].upper()
+    create_interview(ended_room, "Engineer", "Candidate", 10)
+    end_interview(ended_room)
+
+    ended_client = socketio.test_client(app, flask_test_client=flask_client)
+    ended_client.emit("join-room", {"room": ended_room})
+    assert_event(ended_client, "error", "Invalid or expired room")
+    print("OK: ended interview room is rejected")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/webrtc/signaling.py
+++ b/webrtc/signaling.py
@@ -25,6 +25,7 @@ def _count_in_room(room_id):
 
 
 def register_signaling_events(socketio):
+    from models.interview import get_interview
 
     def validate_room(data):
         room = data.get("room")
@@ -36,16 +37,28 @@ def register_signaling_events(socketio):
     def on_join(data):
         from flask import request as flask_request
         room = validate_room(data)
-        if not room: return
-        
+        if not room:
+            emit("error", {"message": "Invalid room"})
+            return
+
+        interview = get_interview(room)
+        if not interview or interview["status"] != "active":
+            emit("error", {"message": "Invalid or expired room"})
+            return
+
         sid = flask_request.sid
 
-        join_room(room)
-        _add_to_room(room, sid)
+        with _rooms_lock:
+            current_members = _rooms.get(room, set())
+            if sid not in current_members and len(current_members) >= 2:
+                emit("error", {"message": "Room is full"})
+                return
 
-        count = _count_in_room(room)
+            join_room(room)
+            _add_to_room(room, sid)
+            count = len(_rooms.get(room, set()))
 
-        # Tell joining user if they're first (initiator) or second
+        # Tell joining user if they're first (initiator) or second.
         emit("room-joined", {
             "room": room,
             "is_initiator": count == 1


### PR DESCRIPTION
## Summary

Adds server-side validation to WebRTC signaling room joins so users can no longer join arbitrary rooms by guessing a `room_id`.

## fixes : #28 

## What Changed

- Validate `join-room` requests against the interview record in the database
- Reject joins when the interview does not exist
- Reject joins when the interview is no longer active
- Reject joins when the room already has 2 participants
- Add a verification script for signaling room guard behavior
- Update config loading to read values from the project `.env` file and support `FLASK_SECRET_KEY`

## Why

Previously, signaling room access relied only on the in-memory room map. That allowed users to attempt joining rooms without confirming:
- the room exists
- the interview is still active
- the room is within the expected 1-on-1 capacity

## Acceptance Criteria

- [x] A third user attempting to join an active 1-on-1 interview is rejected
- [x] Joining an interview marked as ended in the DB is rejected

## Testing

Ran:

```powershell
.\venv\Scripts\python.exe scripts\verify_webrtc_room_guards.py
